### PR TITLE
Fixed demo scenes (added .meta files from befb8cf)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+Library/
+ProjectSettings/
 lib/
 obj/
 Temp/
-*.meta
+

--- a/Assets/PowerInject.meta
+++ b/Assets/PowerInject.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: ff65f9b9d246deb4082d325f41c1d75b
+folderAsset: yes
+timeCreated: 1457781916
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/Annotations.cs.meta
+++ b/Assets/PowerInject/Annotations.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1d437ef3f7694d14888c9d55e2ec5126
+timeCreated: 1455380658
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/ConsoleLogger.cs.meta
+++ b/Assets/PowerInject/ConsoleLogger.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8bdf375e06587974cb353c33d2ac18cc
+timeCreated: 1455713018
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/ConstructorComparable.cs.meta
+++ b/Assets/PowerInject/ConstructorComparable.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 70b7482b8cdc50a4ba2e1eabf42e79a1
+timeCreated: 1455879200
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes.meta
+++ b/Assets/PowerInject/DemoScenes.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: a321c6f8c55088042ad42aae3a700283
+folderAsset: yes
+timeCreated: 1454706904
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/ExecutionOrder.meta
+++ b/Assets/PowerInject/DemoScenes/ExecutionOrder.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: d66978885bb12e14bb571efde8ca61ec
+folderAsset: yes
+timeCreated: 1455205539
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/ExecutionOrder/ExecutionA.cs.meta
+++ b/Assets/PowerInject/DemoScenes/ExecutionOrder/ExecutionA.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0e6665e4b5d0ee3458e4dd55f2ff7773
+timeCreated: 1457713364
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/ExecutionOrder/ExecutionB.cs.meta
+++ b/Assets/PowerInject/DemoScenes/ExecutionOrder/ExecutionB.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0f164aa751be1ee48af0f2528fe80251
+timeCreated: 1457713602
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/ExecutionOrder/ExecutionOrder.unity.meta
+++ b/Assets/PowerInject/DemoScenes/ExecutionOrder/ExecutionOrder.unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7b0d52e6990efde4e8e11ed389d9e4bd
+timeCreated: 1454706904
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/MonsterChase.meta
+++ b/Assets/PowerInject/DemoScenes/MonsterChase.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 95e607fa37d79644c9bc8e5580aa03b3
+folderAsset: yes
+timeCreated: 1455205561
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/MonsterChase/CameraProvider.cs.meta
+++ b/Assets/PowerInject/DemoScenes/MonsterChase/CameraProvider.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7451a8b9139250c4d95a7af29cd5041c
+timeCreated: 1455226095
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/MonsterChase/CameraUpdater.cs.meta
+++ b/Assets/PowerInject/DemoScenes/MonsterChase/CameraUpdater.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: bfe0c8916275c2b489990d745af349ad
+timeCreated: 1455226446
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/MonsterChase/CheckIfOverSelectedMoves.cs.meta
+++ b/Assets/PowerInject/DemoScenes/MonsterChase/CheckIfOverSelectedMoves.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: cc9d011658040d24a8a790b21889814d
+timeCreated: 1456408476
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/MonsterChase/Dot.cs.meta
+++ b/Assets/PowerInject/DemoScenes/MonsterChase/Dot.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 28183c3c48fae9d478375a4f67ea949e
+timeCreated: 1455718414
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/MonsterChase/Floor.mat.meta
+++ b/Assets/PowerInject/DemoScenes/MonsterChase/Floor.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 43d6ac4e2245dc049abb8e1667efc3bf
+timeCreated: 1456419580
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/MonsterChase/GameInit.cs.meta
+++ b/Assets/PowerInject/DemoScenes/MonsterChase/GameInit.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6be3086fd02c5c649be45c97ae163707
+timeCreated: 1456405293
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/MonsterChase/GameState.cs.meta
+++ b/Assets/PowerInject/DemoScenes/MonsterChase/GameState.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d3498bf5c674cab4d812dc13e0447a46
+timeCreated: 1456406372
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/MonsterChase/HUD.cs.meta
+++ b/Assets/PowerInject/DemoScenes/MonsterChase/HUD.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 747443cb4355d1d489a0cab2b0215519
+timeCreated: 1456405649
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/MonsterChase/HeroMetarial.mat.meta
+++ b/Assets/PowerInject/DemoScenes/MonsterChase/HeroMetarial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9aba3d418b89a0c45b6753a1aaa27bde
+timeCreated: 1456419275
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/MonsterChase/ISelectedMoves.cs.meta
+++ b/Assets/PowerInject/DemoScenes/MonsterChase/ISelectedMoves.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 957614b6f75d0c047b58e55993e712ec
+timeCreated: 1455881291
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/MonsterChase/Labyrinth.cs.meta
+++ b/Assets/PowerInject/DemoScenes/MonsterChase/Labyrinth.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 799d0e7cc1d44a84ebd7f72a1ce4f3e5
+timeCreated: 1455205602
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/MonsterChase/Monster.cs.meta
+++ b/Assets/PowerInject/DemoScenes/MonsterChase/Monster.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ab8b8f77d5c392c47ac55607db853c3b
+timeCreated: 1456348796
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/MonsterChase/MonsterChase.unity.meta
+++ b/Assets/PowerInject/DemoScenes/MonsterChase/MonsterChase.unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 71a4a43730f29814b8b7e518d864bda7
+timeCreated: 1455205570
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/MonsterChase/MonsterMaterial.mat.meta
+++ b/Assets/PowerInject/DemoScenes/MonsterChase/MonsterMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bc7794acaef8e9940b7b4f1acd9f11a6
+timeCreated: 1456349331
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/MonsterChase/Player.cs.meta
+++ b/Assets/PowerInject/DemoScenes/MonsterChase/Player.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 39a275dafda818f4a85efa30ba0c32f7
+timeCreated: 1455208325
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/MonsterChase/PointsKeeper.cs.meta
+++ b/Assets/PowerInject/DemoScenes/MonsterChase/PointsKeeper.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ad0d01c5ebe8af74b9fc9112182f3b29
+timeCreated: 1456405134
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/DemoScenes/MonsterChase/SelectedMovesFromKeyboard.cs.meta
+++ b/Assets/PowerInject/DemoScenes/MonsterChase/SelectedMovesFromKeyboard.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 92d5b638c202d3748ac523fdaba098ad
+timeCreated: 1455401492
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/Field.cs.meta
+++ b/Assets/PowerInject/Field.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: adab9907295d23943a8d075b8c6a4295
+timeCreated: 1455710924
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/FinalValue.cs.meta
+++ b/Assets/PowerInject/FinalValue.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d3d38a8e57c83c542a05f95cb8f3bd0b
+timeCreated: 1455710924
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/FunctionObject.cs.meta
+++ b/Assets/PowerInject/FunctionObject.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9a31134c6ade1154a904e94138f7c43a
+timeCreated: 1455380658
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/IKey.cs.meta
+++ b/Assets/PowerInject/IKey.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6a17f660b29679947b67b734ef7b786c
+timeCreated: 1455710923
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/ILogger.cs.meta
+++ b/Assets/PowerInject/ILogger.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: f10eadaa2cd66624d9a0bc41adbc8128
+timeCreated: 1455713018
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/Invokeable.cs.meta
+++ b/Assets/PowerInject/Invokeable.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ef92e67fecbccee479322fda7ecfe17b
+timeCreated: 1455380658
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/KeyProducer.cs.meta
+++ b/Assets/PowerInject/KeyProducer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2a20e4ce82c8945439e5209f436464f8
+timeCreated: 1455710923
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/MethodInfoObject.cs.meta
+++ b/Assets/PowerInject/MethodInfoObject.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6a799015c36177d4d8c2edf6a08f7ff2
+timeCreated: 1455380658
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/NamedTypeKey.cs.meta
+++ b/Assets/PowerInject/NamedTypeKey.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 752ede50b09373746b15c8369ad567d8
+timeCreated: 1455710923
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/PipelineContainer.cs.meta
+++ b/Assets/PowerInject/PipelineContainer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: f0bbde23a1dde334ab581ecee7f9175f
+timeCreated: 1455402916
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/PowerPipeline.cs.meta
+++ b/Assets/PowerInject/PowerPipeline.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: e9dd2630f1bae86449921fd273d3682e
+timeCreated: 1457712217
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/Producer.cs.meta
+++ b/Assets/PowerInject/Producer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 09a52d5e971d5c24aa3d9848a43a395b
+timeCreated: 1455380658
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/Property.cs.meta
+++ b/Assets/PowerInject/Property.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0e9a12b2c9b69fe4180ad0d34cd76f37
+timeCreated: 1457712092
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/ReflectionUtils.cs.meta
+++ b/Assets/PowerInject/ReflectionUtils.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ebfbbc3ce40d8ac49a0ae5402059634b
+timeCreated: 1455380658
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/TypeKey.cs.meta
+++ b/Assets/PowerInject/TypeKey.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6dc034d76ac3bd543b1cf2db7d6cd693
+timeCreated: 1455710923
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/UnityLogger.cs.meta
+++ b/Assets/PowerInject/UnityLogger.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3f936feb83059c8429fc1103cbeddcef
+timeCreated: 1455713018
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PowerInject/Utils.cs.meta
+++ b/Assets/PowerInject/Utils.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7d91e79247519d74cadb54b0d29e58ef
+timeCreated: 1454759005
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This commit fixes broken demo scenes by re-importing the .meta files as they were in commit befb8cf.  I've also updated .gitignore to keep .meta files, and ignore the standard Unity Library and ProjectSettings folders.
